### PR TITLE
updated for qtc 3.4

### DIFF
--- a/src/QtcGtestPlugin.cpp
+++ b/src/QtcGtestPlugin.cpp
@@ -1,3 +1,4 @@
+#include <QAbstractItemModel>
 #include <QAction>
 #include <QTranslator>
 #include <QMenu>

--- a/src/TestProject.cpp
+++ b/src/TestProject.cpp
@@ -2,6 +2,8 @@
 #include <QFileInfo>
 #include <QRegularExpression>
 
+#include <coreplugin/editormanager/editormanager.h>
+#include <coreplugin/idocument.h>
 #include <cpptools/cppmodelmanager.h>
 #include <cpptools/searchsymbols.h>
 #include <cplusplus/DependencyTable.h>
@@ -95,7 +97,7 @@ void TestProject::checkCurrent()
   {
     return;
   }
-  QString file = document->filePath ();
+  QString file = document->filePath ().toString ();
   QStringList files = project->files (Project::ExcludeGeneratedFiles);
   if (!files.contains (file))
   {
@@ -207,7 +209,7 @@ QStringList TestProject::getChangedFiles(int beginRow, int endRow, bool modified
     }
     if (document->isModified () == modifiedFlag) // May not belong to project
     {
-      files << document->filePath ();
+      files << document->filePath ().toString ();
     }
   }
   return files;
@@ -227,8 +229,13 @@ CustomRunConfiguration *TestProject::parse(Project *project)
   dependencyTable_.clear ();
   for (Snapshot::const_iterator i = snapshot.begin (), end = snapshot.end (); i != end; ++i)
   {
-    const QString& fileName = i.key ();
-    dependencyTable_[fileName] = snapshot.filesDependingOn (fileName);
+    const QString& fileName = i.key ().toString ();
+    const Utils::FileNameList& dependingFiles = snapshot.filesDependingOn (fileName);
+    dependencyTable_[fileName].clear ();
+    for (Utils::FileNameList::const_iterator i = dependingFiles.begin (), end = dependingFiles.end (); i != end; ++i)
+    {
+      dependencyTable_[fileName].push_back (i->toString ());
+    }
   }
   gtestIncludeFiles_ = gtestMainIncludes ();
   if (gtestIncludeFiles_.isEmpty ())


### PR DESCRIPTION
Seems like some headers changed and Utils::FileName can't be converted to QString anymore.